### PR TITLE
asyncio Event loop policy, UnicodeEncodeError and planners' exception handling (fixes #3)

### DIFF
--- a/databay/config.py
+++ b/databay/config.py
@@ -1,3 +1,11 @@
+import sys
+import asyncio
+
+# Fix for #3 - Asyncio/aiohttp causes a 'RuntimeError: Event loop is closed' error on ProactorEventLoop, which became default for Python 3.8
+if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
 def initialise():
     import logging
 

--- a/databay/config.py
+++ b/databay/config.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import asyncio
 
@@ -5,12 +6,12 @@ import asyncio
 if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
+IGNORE_WARNINGS = []
 
 def initialise():
     import logging
 
     from databay.misc.logs import ISO8601Formatter
-
 
     iso8601_formatter = ISO8601Formatter('%(asctime)s|%(levelname)-.1s| %(message)s (%(name)s)', millis_precision=3)# / %(threadName)s)')
     iso8601_formatter.set_pretty(True)
@@ -22,4 +23,12 @@ def initialise():
     default_logger = logging.getLogger('databay')
     default_logger.addHandler(stream_handler)
 
-    logging.getLogger('databay').setLevel(logging.WARNING)
+    default_logger.setLevel(logging.WARNING)
+
+    global IGNORE_WARNINGS
+    IGNORE_WARNINGS = os.environ.get('DATABAY_IGNORE_WARNINGS', '').split(';')
+
+    if sys.platform.startswith('win') and \
+        (sys.stdin.encoding == 'windows-1252' or sys.stdout.encoding == 'windows-1252') and \
+        'windows-1252' not in IGNORE_WARNINGS:
+        default_logger.warning('stdin or stdout encoder is set to \'windows-1252\'. This may cause errors with data streaming. Fix by setting following environment variables: \n\nPYTHONIOENCODING=utf-8\nPYTHONLEGACYWINDOWSSTDIO=utf-8\n\nSet DATABAY_IGNORE_WARNINGS=\'windows-1252\' to ignore this warning.')

--- a/databay/link.py
+++ b/databay/link.py
@@ -34,7 +34,7 @@ class Update():
         :returns: "{name}.{index}"
         """
         s = ''
-        if self.name is not '': s += f'{self.name}.'
+        if self.name != '': s += f'{self.name}.'
         s += f'{self.index}'
         return s
 

--- a/databay/planners/aps_planner.py
+++ b/databay/planners/aps_planner.py
@@ -86,8 +86,7 @@ class APSPlanner(BasePlanner):
                     raise type(event.exception)(exception_message).with_traceback(traceback)
                 except TypeError as type_exception:
                     # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
-                    if 'required positional argument' in str(type_exception):
-                        raise Exception(exception_message).with_traceback(traceback) from None
+                    raise Exception(exception_message).with_traceback(traceback) from None
             except Exception as e:
                 _LOGGER.exception(e)
 

--- a/databay/planners/schedule_planner.py
+++ b/databay/planners/schedule_planner.py
@@ -169,8 +169,7 @@ class SchedulePlanner(BasePlanner):
                                 raise type(ex)(exception_message).with_traceback(traceback)
                             except TypeError as type_exception:
                                 # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
-                                if 'required positional argument' in str(type_exception):
-                                    raise RuntimeError(exception_message).with_traceback(traceback) from None
+                                raise RuntimeError(exception_message).with_traceback(traceback) from None
                         except Exception as e:
                             # if self._catch_exceptions:
                             _LOGGER.exception(e)

--- a/test/test/unit/test_config.py
+++ b/test/test/unit/test_config.py
@@ -1,0 +1,82 @@
+import logging
+import os
+from unittest import TestCase, mock
+
+from asynctest import patch, MagicMock
+import asyncio
+from importlib import reload
+
+from databay import config
+
+
+class TestConfig(TestCase):
+
+    def setUp(self):
+        logging.shutdown()
+        reload(logging)
+
+    @patch('sys.platform', 'win32')
+    @patch('sys.version_info')
+    def test_event_loop_policy_3_8(self, version_info):
+        version_info.__getitem__.side_effect = lambda x: [3, 8][x]
+
+        # fake a 3.8 default setup
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+        reload(config)
+
+        self.assertIsInstance(asyncio.get_event_loop_policy(), asyncio.WindowsSelectorEventLoopPolicy, "Asyncio event loop policy should be WindowsSelectorEventLoopPolicy.")
+
+    @patch('sys.platform', 'win32')
+    @patch('sys.version_info')
+    def test_event_loop_policy_3_7(self, version_info):
+        version_info.__getitem__.side_effect = lambda x: [3, 7][x]
+
+        # fake a manual 3.8 default setup
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+        reload(config)
+
+        self.assertIsInstance(asyncio.get_event_loop_policy(), asyncio.WindowsProactorEventLoopPolicy, "Asyncio event loop policy should be WindowsProactorEventLoopPolicy.")
+
+    @patch('databay.config.sys.platform', 'win32')
+    @patch('databay.config.sys.stdout', MagicMock(encoding='windows-1252'))
+    @patch('databay.config.sys.stdin', MagicMock(encoding='windows-1252'))
+    @patch('logging.StreamHandler.emit', lambda x, y: None) #disable stream handler
+    def test_windows_1252(self):
+        with self.assertLogs(logging.getLogger('databay'), level='WARNING') as cm:
+            config.initialise()
+            self.assertTrue('stdin or stdout encoder is set to \'windows-1252\'' in ';'.join(cm.output))
+
+    @patch('databay.config.sys.platform', 'win32')
+    @patch('databay.config.sys.stdout', MagicMock(encoding='utf-8'))
+    @patch('databay.config.sys.stdin', MagicMock(encoding='utf-8'))
+    def test_not_windows_1252(self):
+        databay_logger = logging.getLogger('databay')
+        databay_logger.warning = MagicMock()
+        config.initialise()
+        self.assertTrue('stdin or stdout encoder is set to \'windows-1252\'' not in databay_logger.warning.call_args_list)
+
+
+    @patch('databay.config.sys.platform', 'win32')
+    @patch('databay.config.sys.stdout', MagicMock(encoding='windows-1252'))
+    @patch('databay.config.sys.stdin', MagicMock(encoding='windows-1252'))
+    @patch('logging.Logger.warning')
+    @mock.patch.dict(os.environ, {"DATABAY_IGNORE_WARNINGS": "windows-1252"})
+    def test_windows_1252_ignored(self, warning):
+        config.initialise()
+        string_args = ';'.join([str(call[0][0]) for call in warning.call_args_list])
+        self.assertTrue('stdin or stdout encoder is set to \'windows-1252\'' not in string_args, 'Should not contain windows-1252 warning')
+
+
+    @patch('databay.config.sys.platform', 'win32')
+    @patch('databay.config.sys.stdout', MagicMock(encoding='windows-1252'))
+    @patch('databay.config.sys.stdin', MagicMock(encoding='windows-1252'))
+    @mock.patch.dict(os.environ, {"DATABAY_IGNORE_WARNINGS": "test_ignore"})
+    @patch('logging.StreamHandler.emit', lambda x, y: None) #disable stream handler
+    def test_windows_1252_incorrect_ignore(self):
+        config.initialise()
+        with self.assertLogs(logging.getLogger('databay'), level='WARNING') as cm:
+            config.initialise()
+            self.assertTrue('stdin or stdout encoder is set to \'windows-1252\'' in ';'.join(cm.output))
+


### PR DESCRIPTION
fixes #3

----

Fixes or warns against two errors that can occur on Windows :

- UnicodeEncodeError - if default stdin/stdout encoding is unusual (for instance `windows-1252`)
- Asyncio/Event loop is closed - if run on Python 3.8+

Also fixes exception handling of unusual exceptions on both `APSPlanner` and `SchedulePlanner`.

@pybokeh if you like give this a quick look through - this fixes the issue #3 we've been discussing over the last week.

(This PR additionally contains small tweaks that were found in #3 and a unit test for config.py)