### PR TITLE
renamed both Link._count and Update.index to 'transfer_number'

### DIFF
--- a/databay/link.py
+++ b/databay/link.py
@@ -13,29 +13,29 @@ _LOGGER = logging.getLogger('databay.Link')
 
 class Update():
     """
-    Data structure representing one Link transfer. When converted to string returns :code:`{name}.{index}`
+    Data structure representing one Link transfer. When converted to string returns :code:`{name}.{transfer_number}`
     """
-    def __init__(self, name:str, index:int):
+    def __init__(self, name:str, transfer_number:int):
         """
 
         :type name: str
         :param name: Human readable identifier of the link, see: :class:`Link`.
 
-        :type index: int
-        :param index: Integer identifier of the current transfer.
+        :type transfer_number: int
+        :param transfer_number: Incremental identifier of the current transfer.
         """
         self.name = name
-        self.index = index
+        self.transfer_number = transfer_number
 
     def __repr__(self):
         """
         Provides the formatted transfer string.
 
-        :returns: "{name}.{index}"
+        :returns: "{name}.{transfer_number}"
         """
         s = ''
         if self.name != '': s += f'{self.name}.'
-        s += f'{self.index}'
+        s += f'{self.transfer_number}'
         return s
 
 
@@ -79,7 +79,7 @@ class Link():
         self.add_inlets(inlets)
         self.add_outlets(outlets)
         self._interval = interval
-        self._count = -1
+        self._transfer_number = -1
         self._job = None
         self._name = name
         self._copy_records = copy_records
@@ -229,9 +229,8 @@ class Link():
         Coroutine handling the transfer.
         """
 
-        self._count += 1
-        count = self._count
-        update = Update(name=self.name, index=count)
+        self._transfer_number += 1
+        update = Update(name=self.name, transfer_number=self._transfer_number)
         _LOGGER.debug(f'{update} transfer')
 
         async def inlet_task(inlet):

--- a/docs/source/examples/simple_usage.rst
+++ b/docs/source/examples/simple_usage.rst
@@ -88,7 +88,7 @@ Simple usage
 
             http_to_mongo.0 transfer
 
-        Note the :code:`http_to_mongo.0` prefix in the message. It is the string representation of the :any:`Update` object that represents each individual transfer executed by that particular link. :code:`http_to_mongo` is the name of the link, while :code:`0` represents the index of the transfer.
+        Note the :code:`http_to_mongo.0` prefix in the message. It is the string representation of the :any:`Update` object that represents each individual transfer executed by that particular link. :code:`http_to_mongo` is the name of the link, while :code:`0` represents the incremental index of the transfer.
 
     * Then :any:`HttpInlet` logs its data production:
 


### PR DESCRIPTION
The data representing the time the current transfer is being executed was called `_count` on Link and `index` on Update. This got unified to a common variable name, renamed to better represent the data stored: `transfer_number`. 