### PR TITLE
Feature/python version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ Databay is a Python interface for **scheduled data transfer**. It facilitates tr
 pip install databay
 ```
 
-| Python Version 	| Supported 	|
-|----------------	|-----------	|
-| 3.6            	| ❌         	|
-| 3.7            	| ✅         	|
-| 3.8            	| ✅         	|
-| 3.9            	| Planned   	|
 
 
 ## Documentation
@@ -104,6 +98,14 @@ Example use:
 ---- 
 
 While Databay comes with a handful of built-in inlets and outlets, its strength lies in extendability. To use Databay in your project, create concrete implementations of `Inlet` and `Outlet` classes that handle the data production and consumption functionality you require. Databay will then make sure data can repeatedly flow between the inlets and outlets you create. [Extending inlets][extending_inlets] and [extending outlets][extending_outlets] is easy and has a wide range of customization. Head over to [Extending Databay][extending] section for a detailed explanation or to [Examples][examples] for real use cases. 
+
+## Supported Python Versions
+
+| Python Version 	| <3.6 	| 3.6 	| 3.7 	| 3.8 	| 3.9 	|
+|----------------	|------	|-----	|-----	|-----	|-----	|
+| Supported      	| ❌    	| ✅   	| ✅   	| ✅   	| ✅   	|
+
+
 
 ## <a name="community"></a>Community Contributions
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Databay is a Python interface for **scheduled data transfer**. It facilitates tr
 pip install databay
 ```
 
+| Python Version 	| Supported 	|
+|----------------	|-----------	|
+| 3.6            	| ❌         	|
+| 3.7            	| ✅         	|
+| 3.8            	| ✅         	|
+| 3.9            	| Planned   	|
+
+
 ## Documentation
 
 See full **[Databay documentation][docs]**.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     python_requires='>=3.7 <=3.8'
 )

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3.7',
     ],
+    python_requires='>=3.7 <=3.8'
 )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-    ],
-    python_requires='>=3.7 <=3.8'
+    ]
 )


### PR DESCRIPTION
- Adds `python_requires` param to the package setup script. 
- This will actually block installs through pypi that are not explicitly found in our requires string. So there is certainly a benefit here in adding some sort of install test to check for expected blocking and non-blocking behaviour, but how exactly I'm not sure. 