### PR TITLE
Feature/link immediate transfer

### DIFF
--- a/databay/base_planner.py
+++ b/databay/base_planner.py
@@ -19,7 +19,7 @@ class BasePlanner(ABC):
     Base abstract class for a job planner. Implementations should handle scheduling link transfers based on :py:class:`datetime.timedelta` intervals.
     """
 
-    def __init__(self, links: Union[Link, List[Link]] = None, ignore_exceptions: bool = False, immediate: bool = True):
+    def __init__(self, links: Union[Link, List[Link]] = None, ignore_exceptions: bool = False, immediate_transfer: bool = True):
         """
         :type links: :any:`Link` or list[:any:`Link`]
         :param links: Links that should be added and scheduled.
@@ -28,15 +28,15 @@ class BasePlanner(ABC):
         :param ignore_exceptions: Whether exceptions should be ignored, or halt the planner.
             |default| :code:`False`
 
-        :type immediate: :class:`bool`
-        :param immediate: Whether planner should execute one transfer immediately upon starting.
+        :type immediate_transfer: :class:`bool`
+        :param immediate_transfer: Whether planner should execute one transfer immediately upon starting.
             |default| :code:`True`
         """
         self._links = []
         if links is not None:
             self.add_links(links)
 
-        self.immediate = immediate
+        self.immediate_transfer = immediate_transfer
         self._ignore_exceptions = ignore_exceptions
 
     @property
@@ -116,7 +116,7 @@ class BasePlanner(ABC):
 
         This will also loop over all links and call the on_start callback before starting the planner.
 
-        If :any:`BasePlanner.immediate` is set to True, this function will additionally call :any:`Link.transfer` once for each link managed by this planner before starting.
+        If :any:`BasePlanner.immediate_transfer` is set to True, this function will additionally call :any:`Link.transfer` once for each link managed by this planner before starting.
 
         See :ref:`Start and Shutdown <start_shutdown>` to learn more about starting and shutdown.
         """
@@ -130,7 +130,7 @@ class BasePlanner(ABC):
                 except Exception as ee:
                     self._on_exception(ee, link)
 
-        if self.immediate:
+        if self.immediate_transfer:
             for link in self.links:
                 try:
                     link.transfer()

--- a/databay/base_planner.py
+++ b/databay/base_planner.py
@@ -116,6 +116,8 @@ class BasePlanner(ABC):
 
         This will also loop over all links and call the on_start callback before starting the planner.
 
+        If :any:`BasePlanner.immediate` is set to True, this function will additionally call :any:`Link.transfer` once for each link managed by this planner before starting.
+
         See :ref:`Start and Shutdown <start_shutdown>` to learn more about starting and shutdown.
         """
         _LOGGER.info('Starting %s' % str(self))
@@ -205,6 +207,8 @@ class BasePlanner(ABC):
     def running(self):
         """
         Whether this planner is currently running.
+
+        By default always returns True.
 
         Override this property to indicate when the underlying scheduling functionality is currently running.
         """

--- a/databay/planners/aps_planner.py
+++ b/databay/planners/aps_planner.py
@@ -101,25 +101,6 @@ class ApsPlanner(BasePlanner):
         if event.code is EVENT_JOB_ERROR:
             self._on_exception(event.exception, self.links_by_jobid[event.job_id])
 
-    # def _on_exception(self, exception : Exception, link : Link = None):
-    #     try:
-    #         extra_info = f'\n\nRaised when executing {link}'
-    #         exception_message = str(exception) + f'{extra_info}'
-    #         traceback = exception.__traceback__
-    #
-    #         try:
-    #             raise type(exception)(
-    #                 exception_message).with_traceback(traceback)
-    #         except TypeError as type_exception:
-    #             # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
-    #             raise Exception(exception_message).with_traceback(
-    #                 traceback) from None
-    #     except Exception as e:
-    #         _LOGGER.exception(e)
-    #
-    #     if not self._ignore_exceptions and self.running:
-    #         self.shutdown(wait=False)
-
     def _schedule(self, link: Link):
         """
         Schedule a link. Sets :any:`APS Job <apscheduler.job.Job>` as this link's job.

--- a/databay/planners/aps_planner.py
+++ b/databay/planners/aps_planner.py
@@ -43,7 +43,7 @@ class ApsPlanner(BasePlanner):
                  job_defaults_override: dict = None,
                  ignore_exceptions: bool = False,
                  catch_exceptions: bool = None,
-                 immediate: bool = True):
+                 immediate_transfer: bool = True):
         """
 
         :type links: :any:`Link` or list[:any:`Link`]
@@ -66,8 +66,8 @@ class ApsPlanner(BasePlanner):
         :param ignore_exceptions: Whether exceptions should be ignored or halt the planner.
             |default| :code:`False`
 
-        :type immediate: :class:`bool`
-        :param immediate: Whether planner should execute one transfer immediately upon starting. |default| :code:`True`
+        :type immediate_transfer: :class:`bool`
+        :param immediate_transfer: Whether planner should execute one transfer immediately upon starting. |default| :code:`True`
         """
 
         self._threads = threads
@@ -89,7 +89,7 @@ class ApsPlanner(BasePlanner):
 
         self.links_by_jobid = {}
 
-        super().__init__(links=links, ignore_exceptions=ignore_exceptions, immediate=immediate)
+        super().__init__(links=links, ignore_exceptions=ignore_exceptions, immediate_transfer=immediate_transfer)
 
         if catch_exceptions is not None:  # pragma: no cover
             self._ignore_exceptions = catch_exceptions

--- a/databay/planners/aps_planner.py
+++ b/databay/planners/aps_planner.py
@@ -36,7 +36,14 @@ class ApsPlanner(BasePlanner):
 
     """
 
-    def __init__(self, links: Union[Link, List[Link]] = None, threads: int = 30, executors_override: dict = None, job_defaults_override: dict = None, ignore_exceptions: bool = False, catch_exceptions: bool = None):
+    def __init__(self,
+                 links: Union[Link, List[Link]] = None,
+                 threads: int = 30,
+                 executors_override: dict = None,
+                 job_defaults_override: dict = None,
+                 ignore_exceptions: bool = False,
+                 catch_exceptions: bool = None,
+                 immediate: bool = True):
         """
 
         :type links: :any:`Link` or list[:any:`Link`]
@@ -58,14 +65,12 @@ class ApsPlanner(BasePlanner):
         :type ignore_exceptions: bool
         :param ignore_exceptions: Whether exceptions should be ignored or halt the planner.
             |default| :code:`False`
+
+        :type immediate: :class:`bool`
+        :param immediate: Whether planner should execute one transfer immediately upon starting. |default| :code:`True`
         """
 
         self._threads = threads
-        self._ignore_exceptions = ignore_exceptions
-        if catch_exceptions is not None:  # pragma: no cover
-            self._ignore_exceptions = catch_exceptions
-            warnings.warn(
-                '\'catch_exceptions\' was renamed to \'ignore_exceptions\' in version 0.2.0 and will be permanently changed in version 1.0.0', DeprecationWarning)
 
         if executors_override is None:
             executors_override = {}
@@ -80,30 +85,40 @@ class ApsPlanner(BasePlanner):
         self._scheduler = BlockingScheduler(
             executors=executors, job_defaults=job_defaults, timezone='UTC')
         # self._scheduler = BackgroundScheduler(executors=executors, job_defaults=job_defaults, timezone=utc)
-        self._scheduler.add_listener(self._on_exception, EVENT_JOB_ERROR)
+        self._scheduler.add_listener(self._exception_listener, EVENT_JOB_ERROR)
 
-        super().__init__(links)
+        self.links_by_jobid = {}
 
-    def _on_exception(self, event):
+        super().__init__(links=links, ignore_exceptions=ignore_exceptions, immediate=immediate)
+
+        if catch_exceptions is not None:  # pragma: no cover
+            self._ignore_exceptions = catch_exceptions
+            warnings.warn(
+                '\'catch_exceptions\' was renamed to \'ignore_exceptions\' in version 0.2.0 and will be permanently changed in version 1.0.0', DeprecationWarning)
+
+
+    def _exception_listener(self, event):
         if event.code is EVENT_JOB_ERROR:
-            try:
-                # It would be amazing if we could print the entire Link, but APS serialises Link.transfer to a string and that's all we have from Job's perspective.
-                extra_info = f'\n\nRaised when executing {self._scheduler.get_job(event.job_id)}'
-                exception_message = str(event.exception) + f'{extra_info}'
-                traceback = event.exception.__traceback__
+            self._on_exception(event.exception, self.links_by_jobid[event.job_id])
 
-                try:
-                    raise type(event.exception)(
-                        exception_message).with_traceback(traceback)
-                except TypeError as type_exception:
-                    # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
-                    raise Exception(exception_message).with_traceback(
-                        traceback) from None
-            except Exception as e:
-                _LOGGER.exception(e)
-
-            if not self._ignore_exceptions and self.running:
-                self.shutdown(wait=False)
+    # def _on_exception(self, exception : Exception, link : Link = None):
+    #     try:
+    #         extra_info = f'\n\nRaised when executing {link}'
+    #         exception_message = str(exception) + f'{extra_info}'
+    #         traceback = exception.__traceback__
+    #
+    #         try:
+    #             raise type(exception)(
+    #                 exception_message).with_traceback(traceback)
+    #         except TypeError as type_exception:
+    #             # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
+    #             raise Exception(exception_message).with_traceback(
+    #                 traceback) from None
+    #     except Exception as e:
+    #         _LOGGER.exception(e)
+    #
+    #     if not self._ignore_exceptions and self.running:
+    #         self.shutdown(wait=False)
 
     def _schedule(self, link: Link):
         """
@@ -116,6 +131,7 @@ class ApsPlanner(BasePlanner):
         job = self._scheduler.add_job(link.transfer, trigger=IntervalTrigger(
             seconds=link.interval.total_seconds()))
         link.set_job(job)
+        self.links_by_jobid[job.id] = link
 
     def _unschedule(self, link: Link):
         """
@@ -126,6 +142,7 @@ class ApsPlanner(BasePlanner):
         """
         if link.job is not None:
             link.job.remove()
+            self.links_by_jobid.pop(link.job.id, None)
             link.set_job(None)
 
     def start(self):
@@ -180,6 +197,7 @@ class ApsPlanner(BasePlanner):
         Unschedule and clear all links. It can be used while planner is running. APS automatically removes jobs, so we only clear the links.
         """
         for link in self.links:
+            self.links_by_jobid.pop(link.job.id, None)
             try:
                 link.job.remove()
             except JobLookupError:

--- a/databay/planners/schedule_planner.py
+++ b/databay/planners/schedule_planner.py
@@ -176,23 +176,6 @@ class SchedulePlanner(BasePlanner):
             # TODO: adjust interval to avoid drift - look how APS does it in BlockingScheduler
             time.sleep(self._refresh_interval)
 
-    # def _on_exception(self, exception : Exception, link : Link = None):
-    #     try:  # weird try/catch in order to get whole traceback into logger
-    #         extra_info = f'\n\nRaised when executing {link}'
-    #         exception_message = str(exception) + f'{extra_info}'
-    #         traceback = exception.__traceback__
-    #
-    #         try:
-    #             raise type(exception)(
-    #                 exception_message).with_traceback(traceback)
-    #         except TypeError as type_exception:
-    #             # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
-    #             raise RuntimeError(exception_message).with_traceback(
-    #                 traceback) from None
-    #     except Exception as e:
-    #         _LOGGER.exception(e)
-    #         if not self._ignore_exceptions and self.running:
-    #             self.shutdown(wait=False)
 
     def shutdown(self, wait: bool = True):
         """

--- a/databay/planners/schedule_planner.py
+++ b/databay/planners/schedule_planner.py
@@ -32,7 +32,7 @@ class SchedulePlanner(BasePlanner):
 
     """
 
-    def __init__(self, links: Union[Link, List[Link]] = None, threads: int = 30, refresh_interval: float = 1.0, ignore_exceptions: bool = False, catch_exceptions: bool = None, immediate: bool = True):
+    def __init__(self, links: Union[Link, List[Link]] = None, threads: int = 30, refresh_interval: float = 1.0, ignore_exceptions: bool = False, catch_exceptions: bool = None, immediate_transfer: bool = True):
         """
         :type links: :any:`Link` or list[:any:`Link`]
         :param links: Links that should be added and scheduled.
@@ -52,12 +52,12 @@ class SchedulePlanner(BasePlanner):
         :param ignore_exceptions: Whether exceptions should be ignored, or halt the planner.
             |default| :code:`False`
 
-        :type immediate: :class:`bool`
-        :param immediate: Whether planner should execute one transfer immediately upon starting. |default| :code:`True`
+        :type immediate_transfer: :class:`bool`
+        :param immediate_transfer: Whether planner should execute one transfer immediately upon starting. |default| :code:`True`
         """
 
         self._refresh_interval = refresh_interval
-        super().__init__(links=links, ignore_exceptions=ignore_exceptions, immediate=immediate)
+        super().__init__(links=links, ignore_exceptions=ignore_exceptions, immediate_transfer=immediate_transfer)
         self._running = False
         self._threads = threads
         self._thread_pool = None

--- a/databay/planners/schedule_planner.py
+++ b/databay/planners/schedule_planner.py
@@ -32,9 +32,8 @@ class SchedulePlanner(BasePlanner):
 
     """
 
-    def __init__(self, links: Union[Link, List[Link]] = None, threads: int = 30, refresh_interval: float = 1.0, ignore_exceptions: bool = False, catch_exceptions: bool = None):
+    def __init__(self, links: Union[Link, List[Link]] = None, threads: int = 30, refresh_interval: float = 1.0, ignore_exceptions: bool = False, catch_exceptions: bool = None, immediate: bool = True):
         """
-
         :type links: :any:`Link` or list[:any:`Link`]
         :param links: Links that should be added and scheduled.
             |default| :code:`None`
@@ -49,18 +48,21 @@ class SchedulePlanner(BasePlanner):
             links with intervals smaller than this value will raise a :any:`ScheduleIntervalError`.
             |default| :code:`1.0`
 
-        :type ignore_exceptions: bool
+        :type ignore_exceptions: :class:`bool`
         :param ignore_exceptions: Whether exceptions should be ignored, or halt the planner.
             |default| :code:`False`
+
+        :type immediate: :class:`bool`
+        :param immediate: Whether planner should execute one transfer immediately upon starting. |default| :code:`True`
         """
+
         self._refresh_interval = refresh_interval
-        super().__init__(links)
+        super().__init__(links=links, ignore_exceptions=ignore_exceptions, immediate=immediate)
         self._running = False
         self._threads = threads
         self._thread_pool = None
         self._exc_info = []
         self._exc_lock = threading.Lock()
-        self._ignore_exceptions = ignore_exceptions
         if catch_exceptions is not None:  # pragma: no cover
             self._ignore_exceptions = catch_exceptions
             warnings.warn(
@@ -167,28 +169,30 @@ class SchedulePlanner(BasePlanner):
             if len(self._exc_info) > 0:
                 with self._exc_lock:
                     for exc_info in self._exc_info:
-                        try:  # weird try/catch in order to get whole traceback into logger
-                            ex = exc_info[0][1]
-                            extra_info = f'\n\nRaised when executing {exc_info[1]}'
-                            exception_message = str(ex) + f'{extra_info}'
-                            traceback = ex.__traceback__
-
-                            try:
-                                raise type(ex)(
-                                    exception_message).with_traceback(traceback)
-                            except TypeError as type_exception:
-                                # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
-                                raise RuntimeError(exception_message).with_traceback(
-                                    traceback) from None
-                        except Exception as e:
-                            _LOGGER.exception(e)
-                            if not self._ignore_exceptions and self.running:
-                                self.shutdown(wait=False)
+                        self._on_exception(exc_info[0][1])
 
                     self._exc_info = []
 
             # TODO: adjust interval to avoid drift - look how APS does it in BlockingScheduler
             time.sleep(self._refresh_interval)
+
+    # def _on_exception(self, exception : Exception, link : Link = None):
+    #     try:  # weird try/catch in order to get whole traceback into logger
+    #         extra_info = f'\n\nRaised when executing {link}'
+    #         exception_message = str(exception) + f'{extra_info}'
+    #         traceback = exception.__traceback__
+    #
+    #         try:
+    #             raise type(exception)(
+    #                 exception_message).with_traceback(traceback)
+    #         except TypeError as type_exception:
+    #             # Some custom exceptions won't let you use the common constructor and will throw an error on initialisation. We catch these and just throw a generic RuntimeError.
+    #             raise RuntimeError(exception_message).with_traceback(
+    #                 traceback) from None
+    #     except Exception as e:
+    #         _LOGGER.exception(e)
+    #         if not self._ignore_exceptions and self.running:
+    #             self.shutdown(wait=False)
 
     def shutdown(self, wait: bool = True):
         """

--- a/docs/source/_intro/exception_handling.rst
+++ b/docs/source/_intro/exception_handling.rst
@@ -3,7 +3,7 @@
 Exception handling
 ------------------
 
-If an exception is thrown during transfer, both planners can be set to catch these by passing the :code:`ignore_exceptions=True` parameter on construction. This ensures transfer of remaining links can carry on even if some links are erroneous. If exceptions aren't caught, both :any:`ApsPlanner` and :any:`SchedulePlanner` will log the exception and shutdown.
+If exceptions are thrown during transfer, both planners can be set to log and ignore these by passing the :code:`ignore_exceptions=True` parameter on construction. This ensures transfer of remaining links can carry on even if some links are erroneous. If exceptions aren't ignored, both :any:`ApsPlanner` and :any:`SchedulePlanner` will log the exception and gracefully shutdown.
 
 Additionally, each :any:`Link` can be configured to catch exceptions by passing :code:`ignore_exceptions=True` on construction. This way any exceptions raised by individual inlets and outlets can be logged and ignored, allowing the remaining nodes to continue execution and for the transfer to complete.
 

--- a/docs/source/_intro/start_shutdown.rst
+++ b/docs/source/_intro/start_shutdown.rst
@@ -25,6 +25,6 @@ To stop scheduling links you need to call :any:`shutdown(wait:bool=True) <BasePl
 Just before scheduling starts, :any:`Inlet.on_start` and :any:`Outlet.on_start` callbacks will be propagated through all inlets and outlets. Consequently, just after scheduling shuts down, :any:`Inlet.on_shutdown` and :any:`Outlet.on_shutdown` callbacks will be propagated through all inlets and outlets. In both cases, these callbacks will be called only once for each inlet and outlet. Override these callback methods to implement custom starting and shutdown behaviour in your inlets and outlets.
 
 .. rubric::
-    immediate
+    immediate_transfer
 
-By default BasePlanner will execute :any:`Link.transfer` function on all its links once upon calling :any:`BasePlanner.start`. This is to avoid having to wait for the link's interval to expire before the first transfer. You can disable this behaviour by passing :code:`immediate=False` parameter on construction.
+By default BasePlanner will execute :any:`Link.transfer` function on all its links once upon calling :any:`BasePlanner.start`. This is to avoid having to wait for the link's interval to expire before the first transfer. You can disable this behaviour by passing :code:`immediate_transfer=False` parameter on construction.

--- a/docs/source/_intro/start_shutdown.rst
+++ b/docs/source/_intro/start_shutdown.rst
@@ -24,3 +24,7 @@ To stop scheduling links you need to call :any:`shutdown(wait:bool=True) <BasePl
 
 Just before scheduling starts, :any:`Inlet.on_start` and :any:`Outlet.on_start` callbacks will be propagated through all inlets and outlets. Consequently, just after scheduling shuts down, :any:`Inlet.on_shutdown` and :any:`Outlet.on_shutdown` callbacks will be propagated through all inlets and outlets. In both cases, these callbacks will be called only once for each inlet and outlet. Override these callback methods to implement custom starting and shutdown behaviour in your inlets and outlets.
 
+.. rubric::
+    immediate
+
+By default BasePlanner will execute :any:`Link.transfer` function on all its links once upon calling :any:`BasePlanner.start`. This is to avoid having to wait for the link's interval to expire before the first transfer. You can disable this behaviour by passing :code:`immediate=False` parameter on construction.

--- a/docs/source/_modules/index.rst
+++ b/docs/source/_modules/index.rst
@@ -7,21 +7,21 @@ Source Code
 .. toctree::
   :maxdepth: 1
 
-  link <databay/link>
-  inlet <databay/inlet>
-  outlet <databay/outlet>
   base_planner <databay/base_planner>
   errors <databay/errors>
+  inlet <databay/inlet>
+  link <databay/link>
+  outlet <databay/outlet>
   record <databay/record>
-  inlet_tester <databay/misc/inlet_tester>
   file_inlet <databay/inlets/file_inlet>
   http_inlet <databay/inlets/http_inlet>
   null_inlet <databay/inlets/null_inlet>
   random_int_inlet <databay/inlets/random_int_inlet>
+  inlet_tester <databay/misc/inlet_tester>
   csv_outlet <databay/outlets/csv_outlet>
   file_outlet <databay/outlets/file_outlet>
   mongo_outlet <databay/outlets/mongo_outlet>
   null_outlet <databay/outlets/null_outlet>
   print_outlet <databay/outlets/print_outlet>
-  schedule_planner <databay/planners/schedule_planner>
   aps_planner <databay/planners/aps_planner>
+  schedule_planner <databay/planners/schedule_planner>

--- a/docs/source/extending/extending_base_planner.rst
+++ b/docs/source/extending/extending_base_planner.rst
@@ -5,7 +5,7 @@ Extending BasePlanner
 
 Databay comes with two implementations of BasePlanner - :any:`ApsPlanner` and :any:`SchedulePlanner`. If you require custom scheduling functionality outside of these two interfaces, you can create your own implementation of :any:`BasePlanner`. Have a look at the two existing implementations for reference: `ApsPlanner <../_modules/databay/planners/aps_planner.html>`_ and `SchedulePlanner <../_modules/databay/planners/schedule_planner.html>`_.
 
-To extend the :any:`BasePlanner` you need to provide a way of executing :any:`Link.transfer` method repeatedly by implementing the following four methods. Note that all of these methods are private since they are called internally by BasePlanner and should not be executed directly.
+To extend the :any:`BasePlanner` you need to provide a way of executing :any:`Link.transfer` method repeatedly by implementing the following methods. Note that some of these methods are private since they are called internally by BasePlanner and should not be executed directly.
 
 .. container:: contents local topic
 
@@ -13,6 +13,7 @@ To extend the :any:`BasePlanner` you need to provide a way of executing :any:`Li
     * `_unschedule <extending_base_planner.html#unschedule>`__
     * `_start_planner <extending_base_planner.html#start-planner>`__
     * `_shutdown_planner <extending_base_planner.html#shutdown-planner>`__
+    * `running <extending_base_planner.html#running-property>`__
 
 
 _schedule
@@ -83,15 +84,21 @@ Example from :code:`ApsPlanner._shutdown_planner`:
         self._scheduler.shutdown(wait=wait)
 
 
-Exceptions
-----------
-
-When implementing your planner you should consider that links may raise exceptions when executing. Your planner should anticipate this and allow handling the exceptions appropriately to ensure continuous execution. Both :any:`ApsPlanner` and :any:`SchedulePlanner` allow catching exceptions when :code:`ignore_exceptions=True` is passed on construction, otherwise they will log the exception and shutdown. See :ref:`Exception handling <exception_handling>` for more.
-
 Running property
 ----------------
 
-Apart from extending the necessary methods described above, you may optionally implement the :any:`running <BasePlanner.running>` property. It should return a boolean value indicating whether the scheduler is currently running. This property is exposed for your convenience and is not used by Databay.
+:any:`BasePlanner.running <BasePlanner.running>` property should return a boolean value indicating whether the scheduler is currently running. By default this property always returns True.
+
+Exceptions
+----------
+
+When implementing your planner you should consider that links may raise exceptions when executing. Your planner should anticipate this and allow handling the exceptions appropriately to ensure continuous execution. BasePlanner exposes a protected :code:`BasePlanner._on_exception` method that can be called to handle the exception, allowing to ignore exceptions when :code:`ignore_exceptions=True` is passed on construction. Otherwise the exceptions will be logged and the planner will attempt a graceful shutdown. Both :any:`ApsPlanner` and :any:`SchedulePlanner` support this behaviour by default. See :ref:`Exception handling <exception_handling>` for more.
+
+
+Immediate transfer on start
+---------------------------
+
+By default BasePlanner will execute :any:`Link.transfer` function on all its links once upon calling :any:`BasePlanner.start`. This is to avoid having to wait for the link's interval to expire before the first transfer. You can disable this behaviour by passing :code:`immediate=False` parameter on construction.
 
 
 ----

--- a/test/test/integration/test_aps_planner.py
+++ b/test/test/integration/test_aps_planner.py
@@ -189,27 +189,30 @@ class TestApsPlanner(TestCase):
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')
 
     def _with_exception(self, link, ignore_exceptions):
-        logging.getLogger('databay').setLevel(logging.CRITICAL)
-        # logging.getLogger('databay').setLevel(logging.INFO)
         self.planner = ApsPlanner(ignore_exceptions=ignore_exceptions)
+        self.planner.immediate = False # otherwise planner will never start
 
         link.transfer.side_effect = DummyException()
         link.interval.total_seconds.return_value = 0.02
         self.planner.add_links(link)
 
-        th = Thread(target=self.planner.start, daemon=True)
-        th.start()
-        time.sleep(0.04)
-        link.transfer.assert_called()
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
+            th = Thread(target=self.planner.start, daemon=True)
+            th.start()
+            time.sleep(0.04)
+            link.transfer.assert_called()
 
-        if ignore_exceptions:
-            self.assertTrue(self.planner.running,
-                            'Scheduler should be running')
-            self.planner.shutdown(wait=False)
-            th.join(timeout=2)
-            self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+            if ignore_exceptions:
+                self.assertTrue(self.planner.running,
+                                'Scheduler should be running')
+                self.planner.shutdown(wait=False)
+                th.join(timeout=2)
+                self.assertFalse(th.is_alive(), 'Thread should be stopped.')
 
-        self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            self.assertTrue(
+                'I\'m a dummy exception' in ';'.join(cm.output))
+
 
     def test_ignore_exception(self):
         self._with_exception(self.link, True)
@@ -218,18 +221,21 @@ class TestApsPlanner(TestCase):
         self._with_exception(self.link, False)
 
     def test_uncommon_exception(self):
-        logging.getLogger('databay').setLevel(logging.CRITICAL)
-
         self.link.transfer.side_effect = DummyUnusualException(123, True)
         self.link.interval.total_seconds.return_value = 0.02
         self.planner.add_links(self.link)
 
-        th = Thread(target=self.planner.start, daemon=True)
-        th.start()
-        time.sleep(0.04)
-        self.link.transfer.assert_called()
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
 
-        self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            th = Thread(target=self.planner.start, daemon=True)
+            th.start()
+            time.sleep(0.04)
+            self.link.transfer.assert_called()
+
+            self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            self.assertTrue(
+                '123, True, I\'m an unusual dummy exception' in ';'.join(cm.output))
+
 
     def test_purge(self):
         self.link.interval.total_seconds.return_value = 0.02
@@ -264,5 +270,44 @@ class TestApsPlanner(TestCase):
         self.assertEqual([], self.planner.links)
         self.assertEqual([], self.planner._scheduler.get_jobs())
 
+        th.join(timeout=2)
+        self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+
+    def test_immediate(self):
+        self.link.interval.total_seconds.return_value = 10
+        self.planner.add_links(self.link)
+        th = Thread(target=self.planner.start, daemon=True)
+        th.start()
+        time.sleep(0.01)
+        self.link.transfer.assert_called_once()
+        self.planner.shutdown()
+        th.join(timeout=2)
+        self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+
+    def test_immediate_exception(self):
+        self.link.interval.total_seconds.return_value = 10
+        self.planner._ignore_exceptions = False
+        self.link.transfer.side_effect = DummyException('First transfer exception!')
+        self.planner.add_links(self.link)
+
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
+            th = Thread(target=self.planner.start, daemon=True)
+            th.start()
+            self.link.transfer.assert_called_once()
+            self.assertFalse(self.planner.running, 'Planner should not have started')
+            th.join(timeout=2)
+            self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+            self.assertTrue(
+                'First transfer exception!' in ';'.join(cm.output))
+
+    def test_immediate_off(self):
+        self.link.interval.total_seconds.return_value = 10
+        self.planner.immediate = False
+        self.planner.add_links(self.link)
+        th = Thread(target=self.planner.start, daemon=True)
+        th.start()
+        time.sleep(0.01)
+        self.link.transfer.assert_not_called()
+        self.planner.shutdown()
         th.join(timeout=2)
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')

--- a/test/test/integration/test_aps_planner.py
+++ b/test/test/integration/test_aps_planner.py
@@ -190,7 +190,7 @@ class TestApsPlanner(TestCase):
 
     def _with_exception(self, link, ignore_exceptions):
         self.planner = ApsPlanner(ignore_exceptions=ignore_exceptions)
-        self.planner.immediate = False # otherwise planner will never start
+        self.planner.immediate_transfer = False # otherwise planner will never start
 
         link.transfer.side_effect = DummyException()
         link.interval.total_seconds.return_value = 0.02
@@ -273,7 +273,7 @@ class TestApsPlanner(TestCase):
         th.join(timeout=2)
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')
 
-    def test_immediate(self):
+    def test_immediate_transfer(self):
         self.link.interval.total_seconds.return_value = 10
         self.planner.add_links(self.link)
         th = Thread(target=self.planner.start, daemon=True)
@@ -284,7 +284,7 @@ class TestApsPlanner(TestCase):
         th.join(timeout=2)
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')
 
-    def test_immediate_exception(self):
+    def test_immediate_transfer_exception(self):
         self.link.interval.total_seconds.return_value = 10
         self.planner._ignore_exceptions = False
         self.link.transfer.side_effect = DummyException('First transfer exception!')
@@ -300,9 +300,9 @@ class TestApsPlanner(TestCase):
             self.assertTrue(
                 'First transfer exception!' in ';'.join(cm.output))
 
-    def test_immediate_off(self):
+    def test_immediate_transfer_off(self):
         self.link.interval.total_seconds.return_value = 10
-        self.planner.immediate = False
+        self.planner.immediate_transfer = False
         self.planner.add_links(self.link)
         th = Thread(target=self.planner.start, daemon=True)
         th.start()

--- a/test/test/integration/test_schedule_planner.py
+++ b/test/test/integration/test_schedule_planner.py
@@ -132,7 +132,7 @@ class TestSchedulePlanner(TestCase):
 
     def _with_exception(self, link, ignore_exceptions):
         self.planner = SchedulePlanner(ignore_exceptions=ignore_exceptions)
-        self.planner.immediate = False # otherwise planner will never start
+        self.planner.immediate_transfer = False # otherwise planner will never start
         link.transfer.side_effect = DummyException()
         link.interval.total_seconds.return_value = 0.02
         self.planner._refresh_interval = 0.02
@@ -218,7 +218,7 @@ class TestSchedulePlanner(TestCase):
         th.join(timeout=2)
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')
 
-    def test_immediate(self):
+    def test_immediate_transfer(self):
         self.link.interval.total_seconds.return_value = 10
         self.planner.add_links(self.link)
         th = Thread(target=self.planner.start, daemon=True)
@@ -229,7 +229,7 @@ class TestSchedulePlanner(TestCase):
         th.join(timeout=2)
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')
 
-    def test_immediate_exception(self):
+    def test_immediate_transfer_exception(self):
         self.link.interval.total_seconds.return_value = 10
         self.planner._ignore_exceptions = False
         self.link.transfer.side_effect = DummyException('First transfer exception!')
@@ -245,9 +245,9 @@ class TestSchedulePlanner(TestCase):
                 'First transfer exception!' in ';'.join(cm.output))
 
 
-    def test_immediate_off(self):
+    def test_immediate_transfer_off(self):
         self.link.interval.total_seconds.return_value = 10
-        self.planner.immediate = False
+        self.planner.immediate_transfer = False
         self.planner.add_links(self.link)
         th = Thread(target=self.planner.start, daemon=True)
         th.start()

--- a/test/test/integration/test_schedule_planner.py
+++ b/test/test/integration/test_schedule_planner.py
@@ -131,8 +131,8 @@ class TestSchedulePlanner(TestCase):
                           self.planner.add_links, self.link)
 
     def _with_exception(self, link, ignore_exceptions):
-        logging.getLogger('databay').setLevel(logging.CRITICAL)
         self.planner = SchedulePlanner(ignore_exceptions=ignore_exceptions)
+        self.planner.immediate = False # otherwise planner will never start
         link.transfer.side_effect = DummyException()
         link.interval.total_seconds.return_value = 0.02
         self.planner._refresh_interval = 0.02
@@ -141,19 +141,23 @@ class TestSchedulePlanner(TestCase):
         link.interval.total_seconds.return_value = 0.02
         self.planner.add_links(link)
 
-        th = Thread(target=self.planner.start, daemon=True)
-        th.start()
-        time.sleep(0.04)
-        link.transfer.assert_called()
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
 
-        if ignore_exceptions:
-            self.assertTrue(self.planner.running,
-                            'Scheduler should be running')
-            self.planner.shutdown(wait=False)
-            th.join(timeout=2)
-            self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+            th = Thread(target=self.planner.start, daemon=True)
+            th.start()
+            time.sleep(0.04)
+            link.transfer.assert_called()
 
-        self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            if ignore_exceptions:
+                self.assertTrue(self.planner.running,
+                                'Planner should be running')
+                self.planner.shutdown(wait=False)
+                th.join(timeout=2)
+                self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+
+            self.assertFalse(self.planner.running, 'Planner should be stopped')
+            self.assertTrue(
+                'I\'m a dummy exception' in ';'.join(cm.output))
 
     def test_ignore_exception(self):
         self._with_exception(self.link, True)
@@ -162,19 +166,22 @@ class TestSchedulePlanner(TestCase):
         self._with_exception(self.link, False)
 
     def test_uncommon_exception(self):
-        logging.getLogger('databay').setLevel(logging.CRITICAL)
 
         self.link.transfer.side_effect = DummyUnusualException(
             argA=123, argB=True)
         self.link.interval.total_seconds.return_value = 0.02
         self.planner.add_links(self.link)
 
-        th = Thread(target=self.planner.start, daemon=True)
-        th.start()
-        time.sleep(0.04)
-        self.link.transfer.assert_called()
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
 
-        self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            th = Thread(target=self.planner.start, daemon=True)
+            th.start()
+            time.sleep(0.04)
+            self.link.transfer.assert_called()
+
+            self.assertFalse(self.planner.running, 'Scheduler should be stopped')
+            self.assertTrue(
+                '123, True, I\'m an unusual dummy exception' in ';'.join(cm.output))
 
     def test_purge(self):
         self.link.interval.total_seconds.return_value = 0.02
@@ -195,6 +202,57 @@ class TestSchedulePlanner(TestCase):
         self.assertEqual(self.planner.links, [])
         self.assertEqual(schedule.jobs, [])
 
+        self.planner.shutdown()
+        th.join(timeout=2)
+        self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+
+    def test_start_when_already_running(self):
+        th = Thread(target=self.planner.start, daemon=True)
+        th.start()
+        self.assertTrue(self.planner._running, 'Planner should be running')
+        th2 = Thread(target=self.planner._start_planner, daemon=True)
+        th2.start() # this shouldn't do anything as we're already running
+        th2.join()
+        self.assertFalse(th2.is_alive(), 'Second start thread should have exited.')
+        self.planner.shutdown()
+        th.join(timeout=2)
+        self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+
+    def test_immediate(self):
+        self.link.interval.total_seconds.return_value = 10
+        self.planner.add_links(self.link)
+        th = Thread(target=self.planner.start, daemon=True)
+        th.start()
+        time.sleep(0.01)
+        self.link.transfer.assert_called_once()
+        self.planner.shutdown()
+        th.join(timeout=2)
+        self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+
+    def test_immediate_exception(self):
+        self.link.interval.total_seconds.return_value = 10
+        self.planner._ignore_exceptions = False
+        self.link.transfer.side_effect = DummyException('First transfer exception!')
+        self.planner.add_links(self.link)
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
+            th = Thread(target=self.planner.start, daemon=True)
+            th.start()
+            self.link.transfer.assert_called_once()
+            self.assertFalse(self.planner.running, 'Planner should not have started')
+            th.join(timeout=2)
+            self.assertFalse(th.is_alive(), 'Thread should be stopped.')
+            self.assertTrue(
+                'First transfer exception!' in ';'.join(cm.output))
+
+
+    def test_immediate_off(self):
+        self.link.interval.total_seconds.return_value = 10
+        self.planner.immediate = False
+        self.planner.add_links(self.link)
+        th = Thread(target=self.planner.start, daemon=True)
+        th.start()
+        time.sleep(0.01)
+        self.link.transfer.assert_not_called()
         self.planner.shutdown()
         th.join(timeout=2)
         self.assertFalse(th.is_alive(), 'Thread should be stopped.')

--- a/test/test/unit/test_base_planner.py
+++ b/test/test/unit/test_base_planner.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 import databay
 from databay import BasePlanner, Link
 from databay.errors import MissingLinkError
-from test_utils import fqname
+from test_utils import fqname, DummyException
 
 
 class TestBasePlanner(TestCase):
@@ -129,4 +129,43 @@ class TestBasePlanner(TestCase):
         self.planner._unschedule.assert_called_with(link)
         self.assertEqual(self.planner.links, [])
 
+        self.planner.shutdown()
+
+    @patch(fqname(Link), spec=Link)
+    def test_immediate(self, link):
+        self.planner.add_links(link)
+        self.planner.start()
+        link.transfer.assert_called()
+        self.planner.shutdown()
+
+    @patch(fqname(Link), spec=Link)
+    def test_immediate_exception(self, link):
+        link.transfer.side_effect = DummyException('First transfer exception!')
+        self.planner.add_links(link)
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
+            self.planner.start()
+            self.assertTrue(
+                'First transfer exception!' in ';'.join(cm.output))
+        link.transfer.assert_called()
+        self.planner.shutdown()
+
+    @patch(fqname(Link), spec=Link)
+    def test_link_on_start_exception(self, link):
+        link.on_start.side_effect = DummyException('First transfer exception!')
+        self.planner.add_links(link)
+        with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
+            self.planner.start()
+            self.assertTrue(
+                'First transfer exception!' in ';'.join(cm.output))
+        # self.assertRaises(RuntimeError, self.planner.start)
+        link.on_start.assert_called()
+        self.planner.shutdown()
+
+
+    @patch(fqname(Link), spec=Link)
+    def test_immediate_off(self, link):
+        self.planner.immediate = False
+        self.planner.add_links(link)
+        self.planner.start()
+        link.transfer.assert_not_called()
         self.planner.shutdown()

--- a/test/test/unit/test_base_planner.py
+++ b/test/test/unit/test_base_planner.py
@@ -132,14 +132,14 @@ class TestBasePlanner(TestCase):
         self.planner.shutdown()
 
     @patch(fqname(Link), spec=Link)
-    def test_immediate(self, link):
+    def test_immediate_transfer(self, link):
         self.planner.add_links(link)
         self.planner.start()
         link.transfer.assert_called()
         self.planner.shutdown()
 
     @patch(fqname(Link), spec=Link)
-    def test_immediate_exception(self, link):
+    def test_immediate_transfer_exception(self, link):
         link.transfer.side_effect = DummyException('First transfer exception!')
         self.planner.add_links(link)
         with self.assertLogs(logging.getLogger('databay.BasePlanner'), level='WARNING') as cm:
@@ -163,8 +163,8 @@ class TestBasePlanner(TestCase):
 
 
     @patch(fqname(Link), spec=Link)
-    def test_immediate_off(self, link):
-        self.planner.immediate = False
+    def test_immediate_transfer_off(self, link):
+        self.planner.immediate_transfer = False
         self.planner.add_links(link)
         self.planner.start()
         link.transfer.assert_not_called()


### PR DESCRIPTION
- added immediate mode to BasePlanner allowing to run transfer immediately upon starting
- moved exception handling from concrete planners to BasePlanner
- removed logging.CRITICAL switches from tests
- storing links_by_jobid in ApsPlanner to allow accessing links by APS's jobid
- BasePlanner.running is no longer an optional property and BasePlanner uses it internally
- updated documentation with the new changes

Usage doesn't change at all, as immediate is now the default behaviour.