### PR TITLE
Feature/atexit shutdown

### DIFF
--- a/databay/base_planner.py
+++ b/databay/base_planner.py
@@ -220,6 +220,8 @@ class BasePlanner(ABC):
 
         Override this property to indicate when the underlying scheduling functionality is currently running.
         """
+        return True
+
     def __repr__(self):
         return f"BasePlanner(links={len(self.links)}, shutdown_at_exit={self.shutdown_at_exit})"
 

--- a/docs/source/extending/extending_base_planner.rst
+++ b/docs/source/extending/extending_base_planner.rst
@@ -94,6 +94,11 @@ Running property
 Apart from extending the necessary methods described above, you may optionally implement the :any:`running <BasePlanner.running>` property. It should return a boolean value indicating whether the scheduler is currently running. This property is exposed for your convenience and is not used by Databay.
 
 
+Shutdown atexit
+---------------
+
+Each :any:`BasePlanner` registers an :any:`atexit` callback, which will attempt to gracefully shut the planner down if it is created with :any:`shutdown_at_exit <BasePlanner>` parameter set to :code:`True`.
+
 ----
 
 .. rubric:: Next Steps


### PR DESCRIPTION
* Added atexit callback to BasePlanner which will attempt to gracefully shutdown upon unexpected exit. 
* It is off by default and can be turned on by setting shutdown_at_exit parameter to true.